### PR TITLE
feat: Add language settings (Japanese/English) and i18n system

### DIFF
--- a/.cursor/rules/general-rules.mdc
+++ b/.cursor/rules/general-rules.mdc
@@ -68,3 +68,29 @@ These are custom implementations (not shadcn):
 - `audio-input-button`
 - `audio-bars`
 - `volume-bar`
+
+### Internationalization (i18n) Requirements
+**MANDATORY**: All new UI components and features with user-facing text MUST support both Japanese and English.
+
+- **Never use hardcoded text strings** in JSX components
+- **Always use the i18n system** located at `src/lib/i18n.ts`
+- **Import and use the `useT()` hook** for translations:
+  ```tsx
+  import { useT } from "@/lib/i18n";
+  
+  function MyComponent() {
+    const t = useT();
+    return <div>{t("my.translation.key")}</div>;
+  }
+  ```
+- **Add translation keys** to both `en` and `ja` objects in `TranslationKeys` interface
+- **Follow the naming convention** for translation keys: `section.subsection.key`
+- **Test language switching** in Control Panels → System → Language
+- **Examples of what needs translation**:
+  - Button labels, menu items, dialog titles
+  - Form labels, placeholders, validation messages
+  - Help text, tooltips, descriptions
+  - Error messages, success messages
+  - Any text visible to users
+
+**Language Setting**: Users can switch between languages in Control Panels → System → Language

--- a/.cursorrc
+++ b/.cursorrc
@@ -1,0 +1,31 @@
+# ryOS Project Rules for Cursor
+
+## Internationalization (i18n) - MANDATORY
+When creating any new UI components, features, or user-facing text:
+
+1. **NEVER use hardcoded strings** - All text must be translatable
+2. **ALWAYS use the i18n system** (`src/lib/i18n.ts`)
+3. **Import `useT()` hook** and use translation keys
+4. **Add both Japanese and English translations** to `TranslationKeys`
+5. **Test language switching** in Control Panels → System → Language
+
+Example:
+```tsx
+import { useT } from "@/lib/i18n";
+
+function MyComponent() {
+  const t = useT();
+  return <button>{t("common.save")}</button>; // ✅ Good
+  // return <button>Save</button>; // ❌ Bad - hardcoded
+}
+```
+
+Translation key naming: `section.subsection.key`
+
+This rule applies to:
+- Button labels, menu items, dialog titles
+- Form labels, placeholders, error messages  
+- Help text, tooltips, descriptions
+- Any user-visible text
+
+Language switching: Control Panels → System → Language 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,16 +7,18 @@ import { useAppStoreShallow } from "@/stores/helpers";
 import { BootScreen } from "./components/dialogs/BootScreen";
 import { getNextBootMessage, clearNextBootMessage } from "./utils/bootMessage";
 import { AnyApp } from "./apps/base/types";
+import { setCurrentLanguage } from "@/lib/i18n";
 
 // Convert registry to array
 const apps: AnyApp[] = Object.values(appRegistry);
 
 function App() {
-  const { displayMode, isFirstBoot, setHasBooted } = useAppStoreShallow(
+  const { displayMode, isFirstBoot, setHasBooted, language } = useAppStoreShallow(
     (state) => ({
       displayMode: state.displayMode,
       isFirstBoot: state.isFirstBoot,
       setHasBooted: state.setHasBooted,
+      language: state.language,
     })
   );
   const [bootScreenMessage, setBootScreenMessage] = useState<string | null>(
@@ -27,6 +29,10 @@ function App() {
   useEffect(() => {
     applyDisplayMode(displayMode);
   }, [displayMode]);
+
+  useEffect(() => {
+    setCurrentLanguage(language);
+  }, [language]);
 
   useEffect(() => {
     // Only show boot screen for system operations (reset/restore/format/debug)

--- a/src/apps/control-panels/components/ControlPanelsAppComponent.tsx
+++ b/src/apps/control-panels/components/ControlPanelsAppComponent.tsx
@@ -33,6 +33,8 @@ import { v4 as uuidv4 } from "uuid";
 import { useAuth } from "@/hooks/useAuth";
 import { toast } from "sonner";
 import React from "react";
+import { LANGUAGE_NAMES, setCurrentLanguage, useT } from "@/lib/i18n";
+import { Language } from "@/stores/useAppStore";
 
 interface StoreItem {
   name: string;
@@ -223,6 +225,8 @@ export function ControlPanelsAppComponent({
     masterVolume,
     setMasterVolume,
     setCurrentWallpaper,
+    language,
+    setLanguage,
   } = useAppStoreShallow((s) => ({
     debugMode: s.debugMode,
     setDebugMode: s.setDebugMode,
@@ -253,6 +257,8 @@ export function ControlPanelsAppComponent({
     masterVolume: s.masterVolume,
     setMasterVolume: s.setMasterVolume,
     setCurrentWallpaper: s.setCurrentWallpaper,
+    language: s.language,
+    setLanguage: s.setLanguage,
   }));
 
   // Use auth hook
@@ -295,8 +301,16 @@ export function ControlPanelsAppComponent({
 
   // Log out all devices state
   const [isLoggingOutAllDevices, setIsLoggingOutAllDevices] = useState(false);
+  
+  // Translation function
+  const t = useT();
 
   // Password status is now automatically checked by the store when username/token changes
+
+  // Initialize i18n current language
+  React.useEffect(() => {
+    setCurrentLanguage(language);
+  }, [language]);
 
   // Debug hasPassword value
   React.useEffect(() => {
@@ -410,6 +424,12 @@ export function ControlPanelsAppComponent({
 
   const handleSynthPresetChange = (value: string) => {
     setSynthPreset(value);
+  };
+
+  const handleLanguageChange = (value: string) => {
+    const newLanguage = value as Language;
+    setLanguage(newLanguage);
+    setCurrentLanguage(newLanguage);
   };
 
   // Mute toggle handlers
@@ -1413,19 +1433,19 @@ export function ControlPanelsAppComponent({
                 value="appearance"
                 className="relative flex-1 h-6 px-2 -mb-[1px] rounded-t bg-[#D4D4D4] data-[state=active]:bg-[#E3E3E3] border border-[#808080] data-[state=active]:border-b-[#E3E3E3] shadow-none! text-[16px]"
               >
-                Appearance
+                {t("controlPanels.appearance")}
               </TabsTrigger>
               <TabsTrigger
                 value="sound"
                 className="relative flex-1 h-6 px-2 -mb-[1px] rounded-t bg-[#D4D4D4] data-[state=active]:bg-[#E3E3E3] border border-[#808080] data-[state=active]:border-b-[#E3E3E3] shadow-none! text-[16px]"
               >
-                Sound
+                {t("controlPanels.sound")}
               </TabsTrigger>
               <TabsTrigger
                 value="system"
                 className="relative flex-1 h-6 px-2 -mb-[1px] rounded-t bg-[#D4D4D4] data-[state=active]:bg-[#E3E3E3] border border-[#808080] data-[state=active]:border-b-[#E3E3E3] shadow-none! text-[16px]"
               >
-                System
+                {t("controlPanels.system")}
               </TabsTrigger>
             </TabsList>
 
@@ -1616,6 +1636,32 @@ export function ControlPanelsAppComponent({
                       </div>
                     </div>
                   )}
+                </div>
+
+                <hr className="border-gray-400 my-4" />
+
+                {/* Language Settings Section */}
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <div className="flex flex-col gap-1">
+                      <Label>{t("controlPanels.language.label")}</Label>
+                      <Label className="text-[11px] text-gray-600 font-geneva-12">
+                        {t("controlPanels.language.description")}
+                      </Label>
+                    </div>
+                    <Select value={language} onValueChange={handleLanguageChange}>
+                      <SelectTrigger className="w-[120px]">
+                        <SelectValue placeholder="Select language" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {Object.entries(LANGUAGE_NAMES).map(([key, name]) => (
+                          <SelectItem key={key} value={key}>
+                            {name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
                 </div>
 
                 <hr className="border-gray-400 my-4" />

--- a/src/components/layout/MenuBar.tsx
+++ b/src/components/layout/MenuBar.tsx
@@ -17,6 +17,7 @@ import { useAppStoreShallow } from "@/stores/helpers";
 import { Slider } from "@/components/ui/slider";
 import { Volume1, Volume2, VolumeX, Settings } from "lucide-react";
 import { useSound, Sounds } from "@/hooks/useSound";
+import { useT } from "@/lib/i18n";
 
 const finderHelpItems = [
   {
@@ -115,6 +116,7 @@ function DefaultMenuItems() {
   const launchApp = useLaunchApp();
   const [isHelpDialogOpen, setIsHelpDialogOpen] = useState(false);
   const [isAboutDialogOpen, setIsAboutDialogOpen] = useState(false);
+  const t = useT();
 
   const handleLaunchFinder = (path: string) => {
     launchApp("finder", { initialPath: path });
@@ -130,7 +132,7 @@ function DefaultMenuItems() {
             size="default"
             className="h-6 text-md px-2 py-1 border-none hover:bg-gray-200 active:bg-gray-900 active:text-white focus-visible:ring-0"
           >
-            File
+            {t("menu.file")}
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" sideOffset={1} className="px-0">
@@ -174,7 +176,7 @@ function DefaultMenuItems() {
             size="default"
             className="h-6 text-md px-2 py-1 border-none hover:bg-gray-200 active:bg-gray-900 active:text-white focus-visible:ring-0"
           >
-            Edit
+            {t("menu.edit")}
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" sideOffset={1} className="px-0">
@@ -227,7 +229,7 @@ function DefaultMenuItems() {
             size="default"
             className="h-6 text-md px-2 py-1 border-none hover:bg-gray-200 active:bg-gray-900 active:text-white focus-visible:ring-0"
           >
-            View
+            {t("menu.view")}
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" sideOffset={1} className="px-0">
@@ -390,7 +392,7 @@ function DefaultMenuItems() {
             size="default"
             className="h-6 text-md px-2 py-1 border-none hover:bg-gray-200 active:bg-gray-900 active:text-white focus-visible:ring-0"
           >
-            Help
+            {t("menu.help")}
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" sideOffset={1} className="px-0">

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,0 +1,169 @@
+import { Language } from "@/stores/useAppStore";
+
+// Translation keys interface for type safety
+export interface TranslationKeys {
+  // Common terms
+  "common.ok": string;
+  "common.cancel": string;
+  "common.yes": string;
+  "common.no": string;
+  "common.save": string;
+  "common.delete": string;
+  "common.edit": string;
+  "common.close": string;
+  "common.open": string;
+  "common.settings": string;
+  "common.language": string;
+  
+  // Control Panels
+  "controlPanels.title": string;
+  "controlPanels.appearance": string;
+  "controlPanels.sound": string;
+  "controlPanels.system": string;
+  "controlPanels.language.label": string;
+  "controlPanels.language.description": string;
+  
+  // Menu items
+  "menu.file": string;
+  "menu.edit": string;
+  "menu.view": string;
+  "menu.help": string;
+  "menu.about": string;
+  
+  // App names
+  "apps.finder": string;
+  "apps.textEdit": string;
+  "apps.paint": string;
+  "apps.controlPanels": string;
+  "apps.chats": string;
+  "apps.terminal": string;
+  "apps.internetExplorer": string;
+  "apps.ipod": string;
+  "apps.videos": string;
+  "apps.soundboard": string;
+  "apps.synth": string;
+  "apps.minesweeper": string;
+  "apps.photoBoothe": string;
+  "apps.pc": string;
+}
+
+// Translations object
+const translations: Record<Language, TranslationKeys> = {
+  en: {
+    // Common terms
+    "common.ok": "OK",
+    "common.cancel": "Cancel",
+    "common.yes": "Yes",
+    "common.no": "No",
+    "common.save": "Save",
+    "common.delete": "Delete",
+    "common.edit": "Edit",
+    "common.close": "Close",
+    "common.open": "Open",
+    "common.settings": "Settings",
+    "common.language": "Language",
+    
+    // Control Panels
+    "controlPanels.title": "Control Panels",
+    "controlPanels.appearance": "Appearance",
+    "controlPanels.sound": "Sound",
+    "controlPanels.system": "System",
+    "controlPanels.language.label": "Language",
+    "controlPanels.language.description": "Choose your preferred language",
+    
+    // Menu items
+    "menu.file": "File",
+    "menu.edit": "Edit",
+    "menu.view": "View",
+    "menu.help": "Help",
+    "menu.about": "About",
+    
+    // App names
+    "apps.finder": "Finder",
+    "apps.textEdit": "TextEdit",
+    "apps.paint": "Paint",
+    "apps.controlPanels": "Control Panels",
+    "apps.chats": "Chats",
+    "apps.terminal": "Terminal",
+    "apps.internetExplorer": "Internet Explorer",
+    "apps.ipod": "iPod",
+    "apps.videos": "Videos",
+    "apps.soundboard": "Soundboard",
+    "apps.synth": "Synth",
+    "apps.minesweeper": "Minesweeper",
+    "apps.photoBoothe": "Photo Booth",
+    "apps.pc": "PC",
+  },
+  ja: {
+    // Common terms
+    "common.ok": "OK",
+    "common.cancel": "キャンセル",
+    "common.yes": "はい",
+    "common.no": "いいえ",
+    "common.save": "保存",
+    "common.delete": "削除",
+    "common.edit": "編集",
+    "common.close": "閉じる",
+    "common.open": "開く",
+    "common.settings": "設定",
+    "common.language": "言語",
+    
+    // Control Panels
+    "controlPanels.title": "コントロールパネル",
+    "controlPanels.appearance": "外観",
+    "controlPanels.sound": "サウンド",
+    "controlPanels.system": "システム",
+    "controlPanels.language.label": "言語",
+    "controlPanels.language.description": "優先言語を選択してください",
+    
+    // Menu items
+    "menu.file": "ファイル",
+    "menu.edit": "編集",
+    "menu.view": "表示",
+    "menu.help": "ヘルプ",
+    "menu.about": "について",
+    
+    // App names
+    "apps.finder": "Finder",
+    "apps.textEdit": "テキストエディット",
+    "apps.paint": "ペイント",
+    "apps.controlPanels": "コントロールパネル",
+    "apps.chats": "チャット",
+    "apps.terminal": "ターミナル",
+    "apps.internetExplorer": "Internet Explorer",
+    "apps.ipod": "iPod",
+    "apps.videos": "ビデオ",
+    "apps.soundboard": "サウンドボード",
+    "apps.synth": "シンセ",
+    "apps.minesweeper": "マインスイーパー",
+    "apps.photoBoothe": "Photo Booth",
+    "apps.pc": "PC",
+  },
+};
+
+// Translation function
+export function t(key: keyof TranslationKeys, language: Language): string {
+  return translations[language][key] || translations.en[key] || key;
+}
+
+// Language display names
+export const LANGUAGE_NAMES: Record<Language, string> = {
+  en: "English",
+  ja: "日本語",
+};
+
+// Hook to use translations with current language from store
+let currentLanguage: Language = "en";
+
+export function setCurrentLanguage(language: Language) {
+  currentLanguage = language;
+}
+
+export function useT() {
+  return (key: keyof TranslationKeys) => t(key, currentLanguage);
+}
+
+// Helper to get current language
+export function getCurrentLanguage(): Language {
+  return currentLanguage;
+} 

--- a/src/stores/useAppStore.ts
+++ b/src/stores/useAppStore.ts
@@ -8,6 +8,9 @@ import { ShaderType } from "@/components/shared/GalaxyBackground";
 import { DisplayMode } from "@/utils/displayMode";
 import { AIModel } from "@/types/aiModels";
 import { ensureIndexedDBInitialized } from "@/utils/indexedDB";
+
+// Add language type definition
+export type Language = "ja" | "en";
 // Re-export for backward compatibility
 export type { AIModel } from "@/types/aiModels";
 
@@ -98,6 +101,9 @@ interface AppStoreState extends AppManagerState {
   setSynthPreset: (preset: string) => void;
   displayMode: DisplayMode;
   setDisplayMode: (mode: DisplayMode) => void;
+  // Add language setting
+  language: Language;
+  setLanguage: (language: Language) => void;
   updateWindowState: (
     appId: AppId,
     position: { x: number; y: number },
@@ -173,6 +179,8 @@ export const useAppStore = create<AppStoreState>()(
       setSynthPreset: (preset) => set({ synthPreset: preset }),
       displayMode: "color",
       setDisplayMode: (mode) => set({ displayMode: mode }),
+      language: "en", // Default to English
+      setLanguage: (language) => set({ language }),
       isFirstBoot: true,
       setHasBooted: () => {
         set({ isFirstBoot: false });
@@ -892,6 +900,7 @@ export const useAppStore = create<AppStoreState>()(
         htmlPreviewSplit: state.htmlPreviewSplit,
         currentWallpaper: state.currentWallpaper,
         displayMode: state.displayMode,
+        language: state.language,
         isFirstBoot: state.isFirstBoot,
         wallpaperSource: state.wallpaperSource,
         uiVolume: state.uiVolume,


### PR DESCRIPTION
- Add Language type and language setting to AppStore
- Create i18n system with TypeScript support (src/lib/i18n.ts)
- Add language selection UI to Control Panels > System tab
- Translate MenuBar items (File/Edit/View/Help) and Control Panel tabs
- Initialize i18n in App.tsx
- Add mandatory i18n rules to .cursor/rules/general-rules.mdc and .cursorrc
- Language setting persists and applies globally
- Support for Japanese (日本語) and English